### PR TITLE
Update to latest Cerella Helm chart v1.0.29

### DIFF
--- a/cerella/variables.tf
+++ b/cerella/variables.tf
@@ -21,7 +21,7 @@ variable "prometheus-version" {
 }
 
 variable "cerella-version" {
-  default = "1.0.25"
+  default = "1.0.29"
 }
 
 variable "cluster-ingress-port" {


### PR DESCRIPTION
This is the Cerella Helm version that Odyssey have deployed